### PR TITLE
Replace flexbox with grid in PetsList.css

### DIFF
--- a/src/components/PetCard.css
+++ b/src/components/PetCard.css
@@ -1,6 +1,5 @@
 .PetCard {
   width: 50%;
-  margin: 18px;
   padding: 18px;
   min-width: 300px;
 }

--- a/src/components/PetsList.css
+++ b/src/components/PetsList.css
@@ -1,6 +1,7 @@
 .PetsListSection {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   justify-content: center;
   align-items: center;
-  flex-wrap: wrap;
+  gap: 18px;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/adoptable/",
+  // base: "/adoptable/",
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // base: "/adoptable/",
+  base: "/adoptable/",
 });


### PR DESCRIPTION
Dear team,

I noticed that the pet cards were not fully aligned, so I tried replacing flexbox with grid and now it looks even better. You can check and decide if we wanna keep this change or just stick to flexbox :)

Changes I made: 
1. I replaced flexbox with grid in PetsList.css
2. I removed the margin of .PetCard in PetCard.css (we can use gap instead :D)
3. I commented out *base: "/adoptable/"* in vite.config.js for now so we can properly see the pages.

![IMAGE 2024-02-14 22:50:10](https://github.com/samanta-scavassa/adoptable/assets/152999162/6d535093-5f06-4a1f-bc94-20c1c6ad93a6)

Thank you !
